### PR TITLE
CSS: float table of contents

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -9,9 +9,6 @@ header .small { font-size: 22pt; color: gray; }
 
 ul ul { margin-bottom: 0.5em }
 
-div#TOC { font-size: 10pt; margin: 2em 0 1em 0; padding: 0; background-color: white; }
-div#TOC ul > ul { margin-left: 1em; }
-
 dd { margin-left: 2em; }
 
 hr { height: 1px; color: #aaa; background-color: #aaa; border: 0; margin: .2em 0 .2em 0; }
@@ -50,6 +47,17 @@ nav label { }
 content: "\00A0\25BE";
 }
 
+div#toc {
+  float: right;
+  margin: 10px 0 60px 10px;
+  background: white;
+}
+div#toc:before {
+  content: "Table of contents";
+  margin: 0 0 15px 40px;
+  font-weight: bold;
+  display: block;
+}
 div#toc li { list-style:none; }
 
 div#flattr { float: right; font-size: 12pt; font-family: sans-serif; }


### PR DESCRIPTION
This change was motivated by the MANUAL as its TOC has grown to be quite intimidating, however it will affect the `toc`s on all pages. But I think it actually works quite well on all pages.

Note: `#TOC` didn't seem to take effect in my testing so I removed it.