### PR TITLE
index.txt: use archive url for dead link

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -130,7 +130,7 @@ Copyright 2006-2017 [John MacFarlane].
 [citeproc-hs]:  http://hackage.haskell.org/package/citeproc-hs
 [pandoc-citeproc]:  http://hackage.haskell.org/package/pandoc-citeproc
 [AsciiDoc]:  http://www.methods.co.nz/asciidoc/
-[docx]: http://www.microsoft.com/interop/openup/openxml/default.aspx
+[docx]: http://web.archive.org/web/20120306024812/http://www.microsoft.com/interop/openup/openxml/default.aspx
 [DZSlides]: http://paulrouget.com/dzslides/
 [CSL]: http://citationstyles.org/
 [Slideous]: http://goessner.net/articles/slideous/

--- a/index.txt
+++ b/index.txt
@@ -130,7 +130,7 @@ Copyright 2006-2017 [John MacFarlane].
 [citeproc-hs]:  http://hackage.haskell.org/package/citeproc-hs
 [pandoc-citeproc]:  http://hackage.haskell.org/package/pandoc-citeproc
 [AsciiDoc]:  http://www.methods.co.nz/asciidoc/
-[docx]: http://web.archive.org/web/20120306024812/http://www.microsoft.com/interop/openup/openxml/default.aspx
+[docx]: https://en.wikipedia.org/wiki/Office_Open_XML
 [DZSlides]: http://paulrouget.com/dzslides/
 [CSL]: http://citationstyles.org/
 [Slideous]: http://goessner.net/articles/slideous/


### PR DESCRIPTION
Not sure if the archive URL is the right replacement. The equivalent live URL (IIUC) is https://msdn.microsoft.com/en-us/library/office/gg607163(v=office.14).aspx, but it's version-specific. We could also link to the Wikipedia article https://en.wikipedia.org/wiki/Office_Open_XML.