### PR TITLE
Improve note on installing with Homebrew

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,9 @@
     to a directory of your choice.
     
   - Alternatively, you can install pandoc using
-    [chocolatey](https://chocolatey.org): `choco install pandoc`.
+    [chocolatey](https://chocolatey.org):
+    
+        choco install pandoc
 
   - For PDF output, you'll also need to install LaTeX.
     We recommend [MiKTeX](http://miktex.org/).
@@ -31,10 +33,17 @@
     whatever directory you like.
 
   - Alternatively, you can install pandoc using
-    [homebrew](http://brew.sh): `brew install pandoc`.
-    Note: If you are using macOS < 10.10, this method installs 
-    pandoc from source, so it will take a long time and a lot of 
-    disk space for the ghc compiler and dependent Haskell libraries.
+    [Homebrew](http://brew.sh):
+    
+        brew install pandoc
+
+    This does not include pandoc's citation parser, installed separately:
+    
+        brew install pandoc-citeproc
+    
+    Note: On unsupported versions of macOS (more than three releases old),
+    this method installs pandoc from source, which takes additional time
+    and disk space for the `ghc` compiler and dependent Haskell libraries.
 
   - For PDF output, you'll also need LaTeX.  Because a full [MacTeX]
     installation takes more than a gigabyte of disk space, we recommend


### PR DESCRIPTION
It's now macOS < 10.11, not 10.10, so I added an explanation rather than change it every year.