### PR TITLE
Make option-anchors.lua wrap mentions of options in links to the option descriptions

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -7,6 +7,7 @@ body { font-size: 13pt; line-height: 1.5em; font-family: Georgia, serif; }
 code { font-size: 89%; background-color: transparent; }
 span.nowrap code { white-space: nowrap; }
 pre code { font-size: 89%; }
+a.option code { color: inherit; }
 
 header        { }
 header span   { font-family: Arial, Verdana, sans-serif; }

--- a/tools/option-anchors.lua
+++ b/tools/option-anchors.lua
@@ -29,7 +29,7 @@
   ```
   ## General options {.options}
 
-  [`-C`, `--change`, `-m`, `--mogrify`]{#option--change}
+  [`-C`, `--change`, `-m`, `--mogrify`]{#option--change .option-anchor}
 
   :   Change things.
 
@@ -37,6 +37,21 @@
 
   :   Specify something
   ```
+
+  Additionally Code elements inside a Span element with class
+  `.option-anchor` which start with what looks like an option
+  name receive class `.option-def` (i.e. the above should really
+  say `` `-C`{.option-def} `` etc.!) and Code elements *elsewhere*
+  which start with what looks like an option name are wrapped in
+  a link to the correspondin option definition with class `.option`,
+  e.g.  `` [`-m`](#option--change){.option} `` *if* the option-name-like
+  prefix coincides with an option name which occurs in an option
+  definition.  The purpose of the `.option` class is so that the
+  code element inside the link can be styled to look similar to
+  other links in the document rather than like "plain" code, e.g.
+  with a CSS rule like `a.option code { color: inherit; }`.
+  (Added by BPJ, 1 March 2019.)
+
 
   Authors: Benct Philip Jonsson <bpjonsson@gmail.com>,
            John MacFarlane <jgm@berkeley.edu>.
@@ -54,23 +69,27 @@ local function contains_value(tab, val)
 end
 
 function Pandoc(el)
-   local inoptions = false
-   local newblocks = {}
-   for _,b in ipairs(el.blocks) do
-      if b.t == 'Header' then
-         if contains_value(b.classes, 'options') then
-             inoptions = true
-         else
-             inoptions = false
-         end
-     end
-     if inoptions and b.t == 'DefinitionList' then
-         table.insert(newblocks, add_option_anchors(b))
-     else
-         table.insert(newblocks, b)
-     end
- end
- return pandoc.Pandoc(newblocks, el.meta)
+    local inoptions  = false
+    local newblocks  = {}
+    local opt_id_map = {}
+    for _,b in ipairs(el.blocks) do
+        if b.t == 'Header' then
+            if contains_value(b.classes, 'options') then
+                inoptions = true
+            else
+                inoptions = false
+            end
+        end
+        if inoptions and b.t == 'DefinitionList' then
+            local dl = add_option_anchors(b)
+            dl = collect_option_ids(dl, opt_id_map)
+            table.insert(newblocks, dl)
+        else
+            table.insert(newblocks, b)
+        end
+    end
+    newblocks = add_option_links(newblocks, opt_id_map)
+    return pandoc.Pandoc(newblocks, el.meta)
 end
 
 local function get_option_id (ils)
@@ -95,7 +114,7 @@ local function span_with_id (inlines, id)
             end
         end
     end
-    return { pandoc.Span(inlines, pandoc.Attr(id)) }
+    return { pandoc.Span(inlines, pandoc.Attr(id, {'option-anchor'})) }
 end
 
 function add_option_anchors(el)
@@ -106,4 +125,50 @@ function add_option_anchors(el)
       end
    end
    return el
+end
+
+function collect_option_ids(el, opt_id_map)
+    opt_id_map = opt_id_map or {}
+    local id
+    local code_filter = { Code = function (code)
+            local opt_name = string.match(code.text, '^%-[%-%w]+')
+            if opt_name then
+                opt_id_map[opt_name] = id
+                table.insert(code.attr.classes, 'option-def')
+                return code
+            else
+                return nil
+            end
+        end
+    }
+    local span_filter = { Span = function (span)
+            if contains_value(span.classes, 'option-anchor') then
+                id = '#' .. span.identifier
+                span = pandoc.walk_inline(span, code_filter)
+                return span
+            else
+                return nil
+            end
+        end
+    }
+    return pandoc.walk_block(el, span_filter)
+end
+
+function add_option_links(blocks, opt_id_map)
+    return pandoc.walk_block(pandoc.Div(blocks), { Code = function (el)
+            local opt_name = string.match(el.text, '^%-[%-%w]+')
+            if opt_name then
+                local id = opt_id_map[opt_name]
+                if id then
+                    if contains_value(el.classes, 'option-def') then
+                        return nil
+                    else
+                        return pandoc.Link({el}, id, "", pandoc.Attr("", {'option'}))
+                    end
+                else
+                    return nil
+                end
+            end
+        end
+    }).content
 end


### PR DESCRIPTION
In view of [recent discussion](https://groups.google.com/d/topic/pandoc-discuss/tjC6QqNEbvM/discussion) on problems beginners (and perhaps some non-beginners) have with finding their way among the many command line options I have modified the `option-anchors.lua` filter to also wrap code elements containing option names elsewhere in the manual in links to the option descriptions.  In the course of doing that option anchor spans and option name code elements inside them get labeled with classes so that they can be recognised as such and not get any links themselves.  The links around the option name mentions also get a class allowing the code elements inside them to be styled to look like links so that people don't miss that they are links.  I also added such a style rule to `screen.css`.  If I am not mistaken `print.css` makes all links underlined, which should be sufficient.

I added this description to the filter documentation:

> Additionally Code elements inside a Span element with class
> `.option-anchor` which start with what looks like an option
> name receive class `.option-def` (i.e. the above should really
> say `` `-C`{.option-def} `` etc.!) and Code elements *elsewhere*
> which start with what looks like an option name are wrapped in
> a link to the correspondin option definition with class `.option`,
> e.g. `` [`-m`](#option--change){.option} `` *if* the option-name-like
> prefix coincides with an option name which occurs in an option
> definition.  The purpose of the `.option` class is so that the
> code element inside the link can be styled to look similar to
> other links in the document rather than like "plain" code, e.g.
> with a CSS rule like `a.option code { color: inherit; }`.
> (Added by BPJ, 1 March 2019.)

<s>If you think this is good I can do the same for extensions too, probably as a separate filter.</s>
(Not needed I see now, but perhaps these links should have link color too?)