### PR TITLE
Mention GladTeX for EPUB export

### DIFF
--- a/epub.md
+++ b/epub.md
@@ -141,8 +141,12 @@ Pandoc has an EPUB3 writer.  It renders LaTeX math into MathML, which
 EPUB3 readers are supposed to support (but unfortunately few do).
 
 Of course, this isn't much help if you want EPUB2 output (`pandoc -t epub2`)
-or target readers that don't support MathML. Then you should try using the
-`--webtex` option, which will use a web service to convert the TeX to an image.
+or target readers that don't support MathML. Then you have two options:
+
+1.  Use the `--webtex` option, which will use a web service to convert the TeX to an image.
+2.  Use the `--gladtex` option to convert maths into SVG images on your local
+    machine. The added benefit is the increased accessibility for blind users
+    that are able to see the LaTeX sources of the formulas instead of the image.
 
 [KindleGen]: https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211
 [EPUB]:  https://en.wikipedia.org/wiki/EPUB


### PR DESCRIPTION
I've added a short explanation of GladTeX to the EPUB page. I know that MathML is popular with Pandoc,  but it still is far from being as accessible as what GladTeX provides. Since EPUB is used for accessible lecture materials these days, GladTeX should be mentioned.

As a personal note, I wonder what the advantage of webtex is, apart from that no software needs to be installed :).