### PR TITLE
MANUAL: Show for which formats an extension is supported on hover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 site/
+extension-support.txt

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ MKPAGE = $(PANDOC) --toc --standalone \
 	--lua-filter=tools/option-anchors.lua \
 	--lua-filter=tools/faq-panels.lua \
 	--lua-filter=tools/nowrap.lua \
+	--lua-filter=tools/extension-support.lua \
 	--lua-filter=tools/anchor-links.lua \
 	--lua-filter=tools/include-code-files.lua \
 	--variable time=${TIME}
@@ -22,6 +23,9 @@ VERSION = $(shell pandoc --version | head -1 | awk '{print $$2}')
 
 .PHONY: all
 all : $(SITE) $(ALL) $(SITE)/js/index.js
+
+.PHONY: css
+css : $(patsubst %,$(SITE)/%,css $(CSS))
 
 $(SITE):
 	mkdir -p $@
@@ -41,6 +45,7 @@ $(SITE)/% : %
 .PHONY: clean
 clean:
 	rm -rf $(SITE)
+	rm extension-support.txt
 
 DEMOFILES = $(patsubst %, $(DEMO)/%, MANUAL.txt code.text math.text math.tex template.tex pandoc.1.md footer.html haskell.wiki SLIDES pandoc.css chicago-author-date.csl ieee.csl chicago-fullnote-bibliography.csl biblio.bib CITATIONS howto.xml sample.lua creole.lua example15.md example15.png example33.text twocolumns.docx biblio.json biblio.yaml fishtable.rst species.rst fishwatch.yaml)
 
@@ -91,7 +96,7 @@ $(SITE)/releases.html : release-preamble.md changelog.md
 $(SITE)/installing.html : $(SITE)/installing.txt template.html
 	$(MKPAGE) $< -o $@ -V installbtn
 
-%.html : %.txt nav.html template.html sample.lua
+%.html : %.txt nav.html template.html sample.lua extension-support.txt
 	$(MKPAGE) $< -o $@
 
 %.html : %.md nav.html template.html
@@ -109,6 +114,9 @@ $(SITE)/MANUAL.pdf : MANUAL.txt template.tex
 		--variable linestretch=1.1 \
 		--variable version="$(VERSION)" \
 		--pdf-engine=xelatex
+
+extension-support.txt:
+	sh tools/list-extension-support.sh > $@
 
 upload :
 	rsync -avz --delete --copy-links -e "ssh" $(SITE)/* $(SITE)/.htaccess website:pandoc.org/

--- a/css/print.css
+++ b/css/print.css
@@ -37,3 +37,4 @@ tr {page-break-inside: avoid;}
 
 /*hide various parts from the site*/
 
+.extension-checkbox { display: none; }

--- a/css/screen.css
+++ b/css/screen.css
@@ -162,3 +162,9 @@ div#github-sponsors { float: right; margin-left: 1em; font-size: 10pt; font-fami
   padding: 0.5em 1.5em;
   white-space: normal;
 }
+
+.extension-checkbox {
+  float: right;
+  opacity: 0.5;
+  cursor: help;
+}

--- a/tools/extension-support.lua
+++ b/tools/extension-support.lua
@@ -1,0 +1,69 @@
+-- Adds format support info to Extension: _____ headings.
+--
+-- When changing this script you can do a minimal rebuild with:
+--
+--    make css site/MANUAL.html -B
+
+if FORMAT:match 'html' then
+    local ext_to_formats_enabled = {}
+    local ext_to_formats_disabled = {}
+
+    for line in io.lines('extension-support.txt') do
+        format, enabled, ext = string.match(line, '(.+) (.)(.+)')
+        if ext_to_formats_enabled[ext] == nil then
+            ext_to_formats_enabled[ext] = {}
+        end
+        if ext_to_formats_disabled[ext] == nil then
+            ext_to_formats_disabled[ext] = {}
+        end
+        if enabled == '+' then
+            table.insert(ext_to_formats_enabled[ext], format)
+        else
+            table.insert(ext_to_formats_disabled[ext], format)
+        end
+    end
+
+    function Header(h)
+        local text = pandoc.utils.stringify(h)
+        local ext = string.match(text, 'Extension: (.*)')
+
+        if ext == 'superscript, subscript' then
+            -- Normalize irregular section name.
+            ext = 'superscript'
+        end
+
+        if ext ~= nil then
+            local title = ''
+
+            if #ext_to_formats_enabled[ext] > 0 then
+                title = title .. 'enabled by default for:\n'
+                for _, format in pairs(ext_to_formats_enabled[ext]) do
+                    title = title .. '+ ' .. format .. '\n'
+                end
+            end
+
+            if #ext_to_formats_disabled[ext] > 0 then
+                if #ext_to_formats_enabled[ext] > 0 then
+                    title = title .. '\n'
+                end
+
+                title = title .. 'disabled by default for:\n'
+                for _, format in pairs(ext_to_formats_disabled[ext]) do
+                    title = title .. '- ' .. format .. '\n'
+                end
+            end
+
+            local checkbox = pandoc.Span(
+                {pandoc.Str('±')}, -- content
+                { -- attributes
+                    class = 'extension-checkbox',
+                    ['aria-hidden'] = 'true',
+                    title = title,
+                }
+            )
+            h.content:insert(pandoc.Space())
+            h.content:insert(checkbox)
+            return h
+        end
+    end
+end

--- a/tools/list-extension-support.sh
+++ b/tools/list-extension-support.sh
@@ -1,0 +1,5 @@
+for input_format in $(pandoc --list-input-formats && pandoc --list-output-formats); do
+    for ext in $(pandoc --list-extensions=$input_format); do
+        echo $input_format $ext
+    done
+done | sort | uniq


### PR DESCRIPTION
This commit introduces a new extension-support.lua Lua filter
for MANUAL.html that recognizes headings like the following:

#### Extension: `fenced_code_blocks` ####

And appends a Span with content 🗹 to the heading.
The Span has a title attribute (which browsers display on hover)
with automatically generated text like the following:

  enabled by default for:
  * ipynb
  * markdown
  * markdown_github
  * markdown_phpextra
  * opml

  disabled by default for:
  * markdown_mmd
  * markdown_strict
  * plain

Letting readers quickly check for which formats a specific extension
is supported / enabled by default / disabled by default.